### PR TITLE
Add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "sentinellist",
+  "version": "1.0.0",
+  "author": "zeroknots",
+  "bugs": "https://github.com/zeroknots/sentinellist/issues",
+  "files": [
+    "src"
+  ],
+  "homepage": "https://github.com/zeroknots/sentinellist#readme",
+  "license": "MIT",
+  "repository": "github.com/zeroknots/sentinellist"
+}


### PR DESCRIPTION
Adds `package.json` so that it could be installed as a Node.js package.

More context:
* https://twitter.com/PaulRBerg/status/1736695487057531328
* [`bun install` fails with git dependency oven-sh/bun#5870 (comment)](https://github.com/oven-sh/bun/issues/5870#issuecomment-1872918618)
* https://github.com/evmcheb/solarray/issues/10

