### PR TITLE
Get entries in big endian format

### DIFF
--- a/src/SentinelList.sol
+++ b/src/SentinelList.sol
@@ -185,4 +185,46 @@ library SentinelListLib {
             mstore(array, entryCount)
         }
     }
+
+    /**
+     * Get all entries in the linked list
+     *
+     * @param self The linked list
+     * @param start The start entry
+     * @param pageSize The page size
+     *
+     * @return array All entries in the linked list
+     * @return next The next entry
+     */
+    function getEntriesPaginatedInOrder(
+        SentinelList storage self,
+        address start,
+        uint256 pageSize
+    )
+        internal
+        view
+        returns (address[] memory array, address next)
+    {
+        (array, next) = getEntriesPaginated(self, start, pageSize);
+        array = reverse(array);
+    }
+
+    /**
+     * Reverse all entries in a linked list
+     *
+     * @param array The entries in the linked list
+     *
+     * @return reversedArray Reversed entries
+     */
+    function reverse(address[] memory array)
+        internal
+        pure
+        returns (address[] memory reversedArray)
+    {
+        uint256 sizeOfArray = array.length;
+        reversedArray = new address[](sizeOfArray);
+        for (uint256 i; i < sizeOfArray; ++i) {
+            reversedArray[i] = array[sizeOfArray - i - 1];
+        }
+    }
 }

--- a/test/concrete/SentinelList.tree
+++ b/test/concrete/SentinelList.tree
@@ -82,3 +82,13 @@ SentinelListLib::getEntriesPaginated
     └── when page size is not zero
         ├── it should return all entries until page size
         └── it should return the next entry
+
+SentinelListLib::getEntriesInOrderPaginated
+├── when entry is not contained or sentinel
+│   └── it should revert
+└── when entry is contained or sentinel
+    ├── when page size is zero
+    │   └── it should revert
+    └── when page size is not zero
+        ├── it should return all entries in order until page size
+        └── it should return the next entry

--- a/test/concrete/SentinelList4337Test.t.sol
+++ b/test/concrete/SentinelList4337Test.t.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.25;
 
 import "forge-std/Test.sol";
 import { SentinelList4337Lib, SENTINEL, ZERO_ADDRESS } from "src/SentinelList4337.sol";
-import { SentinelListHelper } from "src/SentinelListHelper.sol";
 
 contract SentinelList4337Test is Test {
     using SentinelList4337Lib for SentinelList4337Lib.SentinelList;

--- a/test/concrete/SentinelListBytes32Test.t.sol
+++ b/test/concrete/SentinelListBytes32Test.t.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.25;
 
 import "forge-std/Test.sol";
 import { LinkedBytes32Lib, SENTINEL, ZERO } from "src/SentinelListBytes32.sol";
-import { SentinelListHelper } from "src/SentinelListHelper.sol";
 
 contract SentinelListBytes32Test is Test {
     using LinkedBytes32Lib for LinkedBytes32Lib.LinkedBytes32;

--- a/test/concrete/SentinelListTest.t.sol
+++ b/test/concrete/SentinelListTest.t.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.25;
 
 import "forge-std/Test.sol";
 import { SentinelListLib, SENTINEL, ZERO_ADDRESS } from "src/SentinelList.sol";
-import { SentinelListHelper } from "src/SentinelListHelper.sol";
 
 contract SentinelListTest is Test {
     using SentinelListLib for SentinelListLib.SentinelList;

--- a/test/concrete/SentinelListTest.t.sol
+++ b/test/concrete/SentinelListTest.t.sol
@@ -261,6 +261,33 @@ contract SentinelListTest is Test {
 
         (address[] memory array, address next) = list.getEntriesPaginated(SENTINEL, 4);
         assertEq(array.length, 4);
+        // Example (items should be considered as addresses):
+        // given the following linked list: 1 2 3 4 5 6 7 8
+        // returned array will be: 8 7 6 5
+        for (uint256 i = 0; i < array.length; i++) {
+            assertEq(array[i], makeAddr(vm.toString(amount - i)));
+        }
+        assertEq(next, makeAddr("5"));
+    }
+
+    function test_GetEntriesPaginatedInOrderWhenPageSizeIsNotZero()
+        external
+        whenEntryIsContainedOrSentinel
+    {
+        // it should return all entries in big endian sequence until page size
+        // it should return the next entry
+        uint256 amount = 8;
+        addMany(amount);
+
+        (address[] memory array, address next) = list.getEntriesPaginatedInOrder(SENTINEL, 4);
+
+        assertEq(array.length, 4);
+        // Example (items should be considered as addresses):
+        // given the following linked list: 1 2 3 4 5 6 7 8
+        // returned array will be: 5 6 7 8
+        for (uint256 i = 0; i < array.length; i++) {
+            assertEq(array[i], makeAddr(vm.toString(amount - array.length + 1 + i)));
+        }
         assertEq(next, makeAddr("5"));
     }
 


### PR DESCRIPTION
Hi,

As the current implementation creates a reversed linked list (little endian notation), I thought it'd be a good idea to have a method which formats the result of the `getEntriesPaginated` method and returns everything in the big endian notation.

**Example:**
Considering the following linked list: `1 2 3 4 5 6 7 8`, by calling the `getEntriesPaginatedInOrder` with `start` equal to `SENTINEL` and `pageSize` to `4`, the result will be `5 6 7 8`, compared to the default `getEntriesPaginated` call which will result in `8 7 6 5`. 

